### PR TITLE
fix for two errors fPIC and dynamic plugin paremeter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 LIBDIR=/usr/lib
 
 install:
-	gcc -Wall -I/usr/include/mysql -I. -shared lib_mysqludf_sys.c -o $(LIBDIR)/lib_mysqludf_sys.so
+	gcc -DMYSQL_DYNAMIC_PLUGIN -fPIC -Wall -I/usr/include/mysql -I. -shared lib_mysqludf_sys.c -o $(LIBDIR)/lib_mysqludf_sys.so


### PR DESCRIPTION
1, fPIC was required in order to make the compilation work on my computer. It might be because it's a 64 bit system and as I understand http://stackoverflow.com/questions/5311515/gcc-fpic-option should do no harm, it makes the program code work memory address independently.
2, Included -DMYSQL_DYNAMIC_PLUGIN gcc paremeter as it has been pointed out by Roland Bouman on http://dev.mysql.com/tech-resources/articles/mysql_i_s_plugins_part1-2.html (to make the "magic" work).
